### PR TITLE
add support for automated cloudfront invalidation / cache busting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
   environment {
     AWS_ACCESS_KEY_ID     = credentials('jenkins-aws-secret-key-id')
     AWS_SECRET_ACCESS_KEY = credentials('jenkins-aws-secret-access-key')
+    AWS_CLOUDFRONT_DISTRIBUTION_ID = credentials('jenkins-aws-cloudfront-distribution-id')
   }
 
   tools {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,16 @@ pipeline {
   environment {
     AWS_ACCESS_KEY_ID     = credentials('jenkins-aws-secret-key-id')
     AWS_SECRET_ACCESS_KEY = credentials('jenkins-aws-secret-access-key')
-    AWS_CLOUDFRONT_DISTRIBUTION_ID = credentials('jenkins-aws-cloudfront-distribution-id')
+    AWS_CLOUDFRONT_DISTRIBUTION_ID_PROD = credentials('jenkins-aws-cloudfront-distribution-id-prod')
+    AWS_CLOUDFRONT_DISTRIBUTION_ID_STAGE = credentials('jenkins-aws-cloudfront-distribution-id-stage')
   }
 
   tools {
     nodejs "node-8.9.4"
+  }
+
+  parameters {
+    booleanParam(defaultValue: false, description: 'Production Release toggle', name: 'IS_PRODUCTION_RELEASE')
   }
 
   stages {
@@ -32,12 +37,21 @@ pipeline {
     }
 
     // Only deploy when building from the master branch
+    // stage by default, otherwise prod if IS_PRODUCTION_RELEASE is true
     stage('Deploy') {
       when {
         expression { BRANCH_NAME == 'master' }
       }
       steps {
-        sh "yarn release"
+        when {
+          expression { IS_PRODUCTION_RELEASE == 'true' }
+        }
+        sh "yarn release --release_env=prod"
+        
+        when {
+          expression { IS_PRODUCTION_RELEASE == 'false' }
+        }
+        sh "yarn release --release_env=staging"
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         when {
           expression { IS_PRODUCTION_RELEASE == 'false' }
         }
-        sh "yarn release --release_env=staging"
+        sh "yarn release --release_env=stage"
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,7 @@ The project is hosted in [AWS](https://aws.amazon.com/) and is setup to deploy c
 
 To release manually run `yarn build && yarn release`
 
-**Note:** the release expects `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to be exported environment variables or defined in a credentials file, e.g _~/.aws/credentials.json_
+**Note:** the release expects the following to be exported environment variables or defined in a credentials file, e.g _~/.aws/credentials.json_
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_CLOUDFRONT_DISTRIBUTION_ID`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ After cloning the repo, do the following to get up and running
 - `yarn develop` - start local development server with file watching, live reload, etc
 - `yarn build` - build the site for production deployment
 - `yarn serve` - builds the site for production and starts a server locally (useful for a local demo)
-- `yarn release` - deploys a build to S3
+- `yarn release --release_env=[stage|prod]` - deploys a build to S3, to either stage or prod
 
 ## Release Management
 The project is hosted in [AWS](https://aws.amazon.com/) and is setup to deploy continously on every merge to master in GitHub by running _running.js_.
@@ -25,11 +25,11 @@ The project is hosted in [AWS](https://aws.amazon.com/) and is setup to deploy c
 1. CloudFront fronts this S3 bucket
 1. Route53 has a `CNAME` entry mapping _www.thegreenhouse.io_ to the CloudFront distrubution
 
-To release manually run `yarn build && yarn release`
+To release manually run `yarn build && yarn release --release_env=[stage|prod]`
 
-**Note:** the release expects the following access credentials to be available, either as environment variables or in a file, e.g _~/.aws/credentials.json_
+**Note:** the release expects the following access credentials to be available, either as environment variables or in a file, e.g _~/.aws/credentials.json_.
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
-- `AWS_CLOUDFRONT_DISTRIBUTION_ID_PROD`
-- `AWS_CLOUDFRONT_DISTRIBUTION_ID_STAGE`
-- `IS_PRODUCTION_RELEASE`
+
+
+**Note: see _release.js_ for additional variables needed.**

--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ After cloning the repo, do the following to get up and running
 ## Release Management
 The project is hosted in [AWS](https://aws.amazon.com/) and is setup to deploy continously on every merge to master in GitHub by running _running.js_.
 1. Jenkins build and deploys to an S3 bucket
-1. Cloudfront fronts this S3 bucket
-1. Route53 has a `CNAME` entry mapping _www.thegreenhouse.io_ to the Cloudfront distrubution
+1. CloudFront fronts this S3 bucket
+1. Route53 has a `CNAME` entry mapping _www.thegreenhouse.io_ to the CloudFront distrubution
 
 To release manually run `yarn build && yarn release`
 
-**Note:** the release expects the following to be exported environment variables or defined in a credentials file, e.g _~/.aws/credentials.json_
+**Note:** the release expects the following access credentials to be available, either as environment variables or in a file, e.g _~/.aws/credentials.json_
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
-- `AWS_CLOUDFRONT_DISTRIBUTION_ID`
+- `AWS_CLOUDFRONT_DISTRIBUTION_ID_PROD`
+- `AWS_CLOUDFRONT_DISTRIBUTION_ID_STAGE`
+- `IS_PRODUCTION_RELEASE`

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-plugin-favicon": "^2.1.1",
     "gatsby-plugin-typography": "^1.7.18",
     "glob": "^7.1.2",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "yargs": "^11.0.0"
   }
 }

--- a/release.js
+++ b/release.js
@@ -44,7 +44,7 @@ glob('./public/**/**', function (er, files) {
         }
       });
 
-      s3.upload({Body: body}).on('httpUploadProgress', (httpUploadProgress)).send(httpUploadSend);
+      s3.upload({Body: body}).on('httpUploadProgress', httpUploadProgress).send(httpUploadSend);
     }
   }
 });
@@ -78,10 +78,10 @@ function invalidateCloudfrontDistribution() {
   
   cloudfront.createInvalidation(params, function(err, data) {
     if (err) {
-      console.log(`FAILED: ${S3_KEY_INDEX_HTML} invlidation request`);
+      console.log(`FAILED: ${S3_KEY_INDEX_HTML} invalidation request`);
       console.log(err, err.stack); // an error occurred
     } else { 
-      console.log(`SUCCESS: ${S3_KEY_INDEX_HTML} invlidation request`);
+      console.log(`SUCCESS: ${S3_KEY_INDEX_HTML} invalidation request`);
     }
   });
 }

--- a/release.js
+++ b/release.js
@@ -100,7 +100,7 @@ function invalidateCloudfrontDistribution() {
       CallerReference: `jenkins-release-${RELEASE_ENVIRONMENT}-${timestamp}`,
       Paths: { 
         Quantity: 1, 
-        Items: [`/${indexObject}`]
+        Items: ['/**/*.html', '/index.html']
       }
     }
   };

--- a/release.js
+++ b/release.js
@@ -86,7 +86,7 @@ function httpUploadSend(err, data) {
   console.log(err, data);
   // trigger an invalidation to cache bust the site on each release
   if (!err && data.key === AWS_S3_BUCKET.PATH.INDEX_HTML) {
-    // invalidateCloudfrontDistribution();
+    invalidateCloudfrontDistribution();
   }
 }
 
@@ -99,7 +99,7 @@ function invalidateCloudfrontDistribution() {
     InvalidationBatch: {
       CallerReference: `jenkins-release-${RELEASE_ENVIRONMENT}-${timestamp}`,
       Paths: { 
-        Quantity: 1, 
+        Quantity: 2, 
         Items: ['/**/*.html', '/index.html']
       }
     }

--- a/release.js
+++ b/release.js
@@ -50,7 +50,7 @@ AWS.config.region = AWS_REGION;
 //   }
 // });
 
-uploads the build directory to S3, our "main method"
+// uploads the build directory to S3, our "main method"
 glob('./public/**/**', function (er, files) {
   for (let i = 0, l = files.length; i < l; i += 1) {
     const filename = files[i];

--- a/release.js
+++ b/release.js
@@ -1,13 +1,40 @@
 
+/*
+ * 
+ * This script assumes the following configuration is available in addition to any access credentials
+ * - process.env.is_production_release - determines the release environment, stage by default
+ * - AWS_CLOUDFRONT_DISTRIBUTION_ID_PROD
+ * - AWS_CLOUDFRONT_DISTRIBUTION_ID_STAGE
+ * 
+ */
+
 const AWS = require('aws-sdk');
 const fs = require('fs');
 const glob = require('glob');
+const yargs = require('yargs').argv;
+
 const s3 = new AWS.S3();
 const cloudfront = new AWS.CloudFront();
 
+// AWS CONFIGURATIONS
 const AWS_REGION = 'us-east-1';
-const S3_BUCKET = 'www.thegreenhouse.io';
-const S3_KEY_INDEX_HTML = 'index.html';
+const AWS_S3_BUCKET = {
+  PROD: 'www.thegreenhouse.io',
+  STAGE: 'stage.thegreenhouse.io',
+  PATH: {
+    INDEX_HTML: 'index.html'
+  }
+};
+
+const AWS_CLOUDFRONT_DISTRIBUTION = {
+  PROD: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID_PROD,
+  STAGE: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID_STAGE
+};
+
+// used to determine whether to deploy to prod or stage
+// PROD is set using a manual release process, so STAGE is default
+const RELEASE_ENVIRONMENT = yargs.release_env === 'prod' ? 'PROD' : 'STAGE';
+console.log(`!!! Releasing to => ${RELEASE_ENVIRONMENT }`);
 
 AWS.config.region = AWS_REGION;
 
@@ -23,7 +50,7 @@ AWS.config.region = AWS_REGION;
 //   }
 // });
 
-// uploads the build directory to S3, our "main method"
+uploads the build directory to S3, our "main method"
 glob('./public/**/**', function (er, files) {
   for (let i = 0, l = files.length; i < l; i += 1) {
     const filename = files[i];
@@ -37,7 +64,7 @@ glob('./public/**/**', function (er, files) {
 
       const s3 = new AWS.S3({
         params: {
-          Bucket: S3_BUCKET,
+          Bucket: AWS_S3_BUCKET[RELEASE_ENVIRONMENT],
           Key: s3Filename,
           ContentType: contentType,
           ACL: 'public-read'
@@ -58,30 +85,32 @@ function httpUploadProgress(evt) {
 function httpUploadSend(err, data) {
   console.log(err, data);
   // trigger an invalidation to cache bust the site on each release
-  if (!err && data.key === S3_KEY_INDEX_HTML) {
-    invalidateCloudfrontDistribution();
+  if (!err && data.key === AWS_S3_BUCKET.PATH.INDEX_HTML) {
+    // invalidateCloudfrontDistribution();
   }
 }
 
 // creates an invalidatation in cloudfront for /index.html for cache busting on each release
 function invalidateCloudfrontDistribution() {
+  const timestamp = new Date().getTime();
+  const indexObject = AWS_S3_BUCKET.PATH.INDEX_HTML;
   const params = {
-    DistributionId: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID,
+    DistributionId: AWS_CLOUDFRONT_DISTRIBUTION[RELEASE_ENVIRONMENT],
     InvalidationBatch: {
-      CallerReference: 'jenkins-release' + new Date().getTime(),
+      CallerReference: `jenkins-release-${RELEASE_ENVIRONMENT}-${timestamp}`,
       Paths: { 
         Quantity: 1, 
-        Items: [`/${S3_KEY_INDEX_HTML}`]
+        Items: [`/${indexObject}`]
       }
     }
   };
   
   cloudfront.createInvalidation(params, function(err, data) {
     if (err) {
-      console.log(`FAILED: ${S3_KEY_INDEX_HTML} invalidation request`);
+      console.log(`FAILED: on ${indexObject} invalidation request`);
       console.log(err, err.stack); // an error occurred
     } else { 
-      console.log(`SUCCESS: ${S3_KEY_INDEX_HTML} invalidation request`);
+      console.log(`SUCCESS: for ${indexObject} invalidation request`);
     }
   });
 }

--- a/release.js
+++ b/release.js
@@ -2,7 +2,7 @@
 /*
  * 
  * This script assumes the following configuration is available in addition to any access credentials
- * - process.env.is_production_release - determines the release environment, stage by default
+ * - process.env.release_env - used determines the release environment, values can be prod or stage, with stage the default
  * - AWS_CLOUDFRONT_DISTRIBUTION_ID_PROD
  * - AWS_CLOUDFRONT_DISTRIBUTION_ID_STAGE
  * 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,14 @@ cliui@^3.0.3, cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -3146,7 +3154,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
@@ -8801,6 +8809,12 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.7.1.tgz#e60432658a3387ff269c028eacde4a512e438dff"
@@ -8818,6 +8832,23 @@ yargs@4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^3.31.0:
   version "3.32.0"


### PR DESCRIPTION
resolves #23 

1. updates release script to invalidate _index.html_ on each release, if it has been successfully uploaded to S3