### PR TITLE
remove default link underline style for header link

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -3,6 +3,10 @@
     width: 100%;
   }
 
+  & .header a {
+    color: none;
+  }
+
   & header {
     display: none;
   }


### PR DESCRIPTION
removes the blue underline
<img width="574" alt="Screen Shot 2020-07-16 at 10 47 05 PM" src="https://user-images.githubusercontent.com/895923/87743607-4e9bd700-c7b7-11ea-92f6-afcefc954916.png">