### PR TITLE
set banner to forward slash for home page link

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -16,7 +16,7 @@ class HeaderComponent extends LitElement {
   render() {
     return html`
       <div class="header"> 
-        <a href="https://www.thegreenhouse.io/">
+        <a href="/" title="Return to the the home page">
           <header></header>
           <h2 class="caption">A DREAMER BY DESIGN</h2>
         </a>

--- a/src/components/header/header.spec.js
+++ b/src/components/header/header.spec.js
@@ -34,7 +34,7 @@ describe('Header Component', () => {
     it('should have a link to the project website', () => { 
       const link = header.shadowRoot.querySelectorAll('.header a')[0];
 
-      expect(link.href).toBe('https://www.thegreenhouse.io/');
+      expect(link.href.replace('http://localhost:9876', '')).toBe('/');
     });
   });
 


### PR DESCRIPTION
1. Now home page banner always references `/` so it will return the home page from any environment
1. Added `title` for `<a>` tag