### PR TITLE
adopt Greenwood strict mode

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,5 +1,5 @@
 const pluginGoogleAnalytics = require('@greenwood/plugin-google-analytics');
-const pluginPolyfills = require('@greenwood/plugin-polyfills');
+// const pluginPolyfills = require('@greenwood/plugin-polyfills');
 const DESCRIPTION = 'Personal site and blog for Owen Buckley and The Greenhouse I/O.  Ideas are built here.';
 const FAVICON_HREF = '/assets/favicon.ico';
 const TITLE = 'The Greenhouse I/O';
@@ -28,9 +28,9 @@ module.exports = {
   plugins: [
     ...pluginGoogleAnalytics({
       analyticsId: 'UA-147204327-1'
-    }),
+    })
 
-    ...pluginPolyfills()
+    // ...pluginPolyfills()
   ]
 
 };

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,10 +1,11 @@
 const pluginGoogleAnalytics = require('@greenwood/plugin-google-analytics');
-// const pluginPolyfills = require('@greenwood/plugin-polyfills');
 const DESCRIPTION = 'Personal site and blog for Owen Buckley and The Greenhouse I/O.  Ideas are built here.';
 const FAVICON_HREF = '/assets/favicon.ico';
 const TITLE = 'The Greenhouse I/O';
 
 module.exports = {
+  optimization: 'strict',
+
   title: TITLE,
 
   meta: [
@@ -29,8 +30,6 @@ module.exports = {
     ...pluginGoogleAnalytics({
       analyticsId: 'UA-147204327-1'
     })
-
-    // ...pluginPolyfills()
   ]
 
 };

--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
     "test:tdd": "yarn clean && karma start"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.8.0",
-    "@greenwood/plugin-google-analytics": "^0.8.0",
-    "@greenwood/plugin-polyfills": "^0.8.0",
+    "@greenwood/cli": "^0.9.0",
+    "@greenwood/plugin-google-analytics": "^0.9.0",
     "eslint": "^6.1.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine": "^3.3.1",

--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -47,32 +47,32 @@
 }
 
 @media (min-width: 300px) {
-  :host {
-    & .card-header-icon {
-      display: none;
+  :host .card {
+    & .wrapper {
+      border: none;
     }
 
-    & .card {
-      border: none;
+    & .card-header-icon {
+      display: none;
     }
   }
 }
 
 @media (min-width: 700px) {
-  :host {
-    & .card {
+  :host .card {
+    & .wrapper {
       border: 2px solid #020202;
     }
   
     & .card-header-icon {
       display: inline;
       grid-column: col-start / span 2;
-      grid-row: 1 / 6;  /* autoprefixer: off */
+      grid-row: 1 / 6;
     }
 
     & .card-header {
       grid-column: col-start 3 / span 10;
-      grid-row: 1 / 6; /* autoprefixer: off */
+      grid-row: 1 / 6;
     }
   }
 }

--- a/src/templates/about-template.js
+++ b/src/templates/about-template.js
@@ -9,15 +9,9 @@ class AboutTemplate extends LitElement {
   constructor() {
     super();
 
-    this.SECTIONS = {
-      SPEAKING: 'SPEAKING',
-      WRITING: 'WRITING'
-    };
-
-    this.socialLinksMap = []; // new SocialLinksService().getLinksAsMap(),
+    this.socialLinksMap = [];
     this.articles = new ArticlesService().getModeledArticles(),
-    this.presentations = new PresentationsService().getModeledPresentations(),
-    this.activeSection = this.SECTIONS.SPEAKING;
+    this.presentations = new PresentationsService().getModeledPresentations();
   }
   
   static get properties() {
@@ -27,9 +21,6 @@ class AboutTemplate extends LitElement {
       },
       presentations: {
         type: Array
-      },
-      activeSection: {
-        type: String
       }
     };
   }
@@ -59,51 +50,48 @@ class AboutTemplate extends LitElement {
         display: block;
         margin: 0 10px;
       }
+
+      .hidden {
+        display: none;
+      }
     `;
   }
 
-  setActiveSection(section) {
-    this.activeSection = section;
-  }
-
-  getContent() {
-    let content = this.activeSection;
-
-    switch (this.activeSection) {
-
-      case this.SECTIONS.SPEAKING:
-        content = html`<app-card-list class="content-speaking" .items=${this.presentations}></app-card-list>`;
-        break;
-      case this.SECTIONS.WRITING:
-        content = html`
-          <div>
-            <app-card-list class="content-writing" .items=${this.articles}></app-card-list>
-
-            <p class="cta">Visit my <a target="_blank" href="https://medium.com/@thegreenhouseio">Medium</a> page for other articles Ive done!</p>
-          </div>
-        `;
-        break;
-      default:
-        content = '';
-    
-    }
-
-    return content;
-  }
-
   render() {
-    const content = this.getContent();
-
     return html`
+      <script>
+        function setVisibleContent(activeContent) {
+          if (activeContent === 'speaking') {
+            document.querySelector('.content-speaking').classList.remove('hidden');
+            document.querySelector('.content-writing').classList.add('hidden');
+          } else if (activeContent === 'writing'){
+            document.querySelector('.content-speaking').classList.add('hidden');
+            document.querySelector('.content-writing').classList.remove('hidden');
+          }
+        }
+      </script>
+
       <div>
         <entry></entry>
 
         <div class="content-links">
-          <h2 class="link-speaking" @click=${() => this.setActiveSection(this.SECTIONS.SPEAKING)}><u>Speaking</u></h2>
-          <h2 class="link-writing" @click=${() => this.setActiveSection(this.SECTIONS.WRITING)}><u>Writing</u></h2>
+          <h2 class="link-speaking" onclick="setVisibleContent('speaking')"><u>Speaking</u></h2>
+          <h2 class="link-writing" onclick="setVisibleContent('writing');"><u>Writing</u></h2>
         </div>
 
-        ${ content }
+        <div class="content-blocks">
+          
+          <div class="content-speaking">
+            <app-card-list class="content-speaking" .items=${this.presentations}></app-card-list>
+          </div>
+
+          <div class="content-writing hidden">
+            <app-card-list class="content-writing" .items=${this.articles}></app-card-list>
+            <p class="cta">Visit my <a target="_blank" href="https://medium.com/@thegreenhouseio">Medium</a> page for other articles Ive done!</p>
+          </div>
+          
+        </div>
+
       </div>
     `;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,10 +835,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@greenwood/cli@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.8.0.tgz#8361a6e8c71e0726a947fda1932edb152dca0e04"
-  integrity sha512-GTvw2i/FJ0Eq/+WAolokJ2gchbgKYRgi2r3WcDD6QYNU7ajDdQH7E5GRN1t5ArefNNL06rUxxunrSEVLzM6XSA==
+"@greenwood/cli@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/cli/-/cli-0.9.0.tgz#9b4eb3dea197a21dd3fd6644faea91a092ba39c7"
+  integrity sha512-RiUPzlPsih7m/SUcpW1UwNcGlAO01YO0byRfFVqBwOs1BHVspahSKIvT5qy7HST5BBhZBSvTW4BbfBVUakJBMA==
   dependencies:
     "@babel/core" "^7.8.3"
     "@babel/plugin-syntax-dynamic-import" "^7.8.3"
@@ -886,17 +886,10 @@
     webpack-manifest-plugin "^2.0.4"
     webpack-merge "^4.2.1"
 
-"@greenwood/plugin-google-analytics@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.8.0.tgz#066046b8ae3f0313504110d4f1059442ed56992c"
-  integrity sha512-jiypmCOYgV0owLcPkStdiK0VmBE20wDGFZLDm4u0e/aYWCvBI+3C5cTZho0BhE9ZHrH1ZJ6XPM+pQH7aGjIWyQ==
-
-"@greenwood/plugin-polyfills@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@greenwood/plugin-polyfills/-/plugin-polyfills-0.8.0.tgz#25fd431a4071e0297cae81576c18848fda007c22"
-  integrity sha512-e6psE4jAvS4meP+CFJ4XE9SqGrm/BoRfnxD+YKeS+e4U6xgCvJdkWEe/SZaUibYEKpjC1gaQ3QaAg2LSm6x4qg==
-  dependencies:
-    "@webcomponents/webcomponentsjs" "^2.3.0"
+"@greenwood/plugin-google-analytics@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@greenwood/plugin-google-analytics/-/plugin-google-analytics-0.9.0.tgz#1cb2facea5743c48ac48e83aed7d63dc96aca5a5"
+  integrity sha512-einiYSaC23gu9wRnNG4tlZvXX/9I9NcQ4fRznrhkWa0UpDO+CoVJDp455P4i/joXSlGgHzOq2Iyys1m9tTqofQ==
 
 "@koa/cors@^2.2.1":
   version "2.2.3"


### PR DESCRIPTION
resolves #157  and upgrades to [Greenwood v0.9.0](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.9.0)

1. Update selectors to support Greenwood **strict** mode
1. In **strict** mode, Polyfills plugin is not needed

The inline `<script>` work around doesn't work in `develop` mode though 😢 

## Before
![Screen Shot 2020-08-08 at 3 26 52 PM](https://user-images.githubusercontent.com/895923/89718322-a7f8bf80-d98b-11ea-9518-b3f4782c81b7.png)

## After
![Screen Shot 2020-08-08 at 3 26 26 PM](https://user-images.githubusercontent.com/895923/89718320-a3340b80-d98b-11ea-8a13-cf2dad274fe3.png)

TODO
1. [x] Before / after benchmarks
1. [x] Delete polyfills plugin