### PR TITLE
add default content height to avoid footer jumping

### DIFF
--- a/src/templates/app-template.js
+++ b/src/templates/app-template.js
@@ -10,7 +10,7 @@ class AppComponent extends LitElement {
     return css`
       ${unsafeCSS(pageCss)}
 
-      .gwd-content-outlet {
+      .outlet {
         min-height: 100vh
       }
     `;


### PR DESCRIPTION
Fixed issue with `min-height` to avoid flash of content / footer jumping while content loads in SPA mode.  same as seen in https://github.com/ProjectEvergreen/greenwood/issues/394