### PR TITLE
fix emoji for post of new project idea

### DIFF
--- a/src/pages/blog/2020/04/07/index.md
+++ b/src/pages/blog/2020/04/07/index.md
@@ -1,6 +1,6 @@
 ---
 template: 'post'
-title: 'Git Explorer 🔍'
+title: 'Git Explorer 💡'
 date: '04.07.2020'
 description: 'Local git repository viewer'
 image: '/assets/blog-post-images/git.png'


### PR DESCRIPTION
Usually new project posts get a lightbulb icon 💡 

**Git Explorer** project should have its icon changed as a result
<img width="591" alt="Screen Shot 2020-10-26 at 3 24 52 PM" src="https://user-images.githubusercontent.com/895923/97218831-97443280-179f-11eb-90a7-194163089d7a.png">
