### PR TITLE
integrate prismjs syntax highlighting

### DIFF
--- a/src/pages/blog/2020/08/15/index.md
+++ b/src/pages/blog/2020/08/15/index.md
@@ -10,7 +10,7 @@ Every once in a while I get that itch to automate something that I find myself r
 
 Whenever I start a new (JavaScript) project, there's usually a common set of tools that I bring along for the ride with me each time.  Awesome tools **ESLint**, **Mocha**, and more!  Often times I find myself just copy / pasting the dot and config files from one repository directory to another one.  Essentially just doing this everytime
 
-```
+```bash
 $ cp -r /path/to/some/project .
 ```
 

--- a/src/pages/blog/2020/10/28/index.md
+++ b/src/pages/blog/2020/10/28/index.md
@@ -20,7 +20,8 @@ In this way, given a user's config and content, **Greenwood** can ensure critica
 <a href="https://github.com/thescientist13/gallinago" target="_blank" rel="noopener" onclick="getOutboundLink('https://github.com/thescientist13/gallinago');"><b>Gallinago</b></a> is the standalone tool I created that allows one to essentially stub out an entire user's "workspace" and then run your CLI against it, and see (and test!) what the output is.
 
 For example, if a user had a directory for their project like this in **Greenwood**:
-```
+
+```bash
 src/
   pages/
     index.md
@@ -32,7 +33,8 @@ src/
 ```
 
 The generated output should be something like this:
-```
+
+```bash
 public/
   index.html
   blog/

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -1,0 +1,2 @@
+/* https://prismjs.com/examples.html */
+@import url('../../node_modules/prismjs/themes/prism-solarizedlight.css');

--- a/src/templates/post-template.js
+++ b/src/templates/post-template.js
@@ -1,7 +1,8 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement, unsafeCSS } from 'lit-element';
 import client from '@greenwood/cli/data/client';
 import gql from 'graphql-tag';
 import '../components/blog-post/blog-post';
+import postCss from '../styles/post.css';
 import '../styles/theme.css';
 
 class PostTemplate extends LitElement {
@@ -28,6 +29,8 @@ class PostTemplate extends LitElement {
 
   static get styles() {
     return css`
+      ${unsafeCSS(postCss)}
+
       p {
         width: 60%;
         margin: 10px auto;
@@ -48,8 +51,8 @@ class PostTemplate extends LitElement {
         text-align: center;
       }
 
-      pre {
-        width: 400px;
+      :host pre {
+        width: 60%;
         display: block;
         margin: 0 auto;
         text-align: left;


### PR DESCRIPTION
resolves #175, though I think this is suffering from the same issue as #171 in that when in 'strict' mode, and all JS is stripped away, so to that includes any _CSS-in-JS_ as well.

For example, in development
<img width="1084" alt="Screen Shot 2020-12-14 at 3 28 21 PM" src="https://user-images.githubusercontent.com/895923/102132829-25dd4380-3e22-11eb-828a-11c9f4ac510f.png">


In production
<img width="1218" alt="Screen Shot 2020-12-14 at 3 32 06 PM" src="https://user-images.githubusercontent.com/895923/102132839-2970ca80-3e22-11eb-83a7-bc9e5221ee7d.png">


That said, in the new version of Greenwood, there will be a better away around this so maybe just wait until the `0.10.0` upgrade?