### PR TITLE
apply loading=lazy to images and iframes in cards

### DIFF
--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -34,10 +34,10 @@ class CardComponent extends LitElement {
       ? html`<a href=${item.slides} target="_blank" class="card-slides">📎 (slides)</a>`
       : ''; 
     const img = item && item.img 
-      ? html`<img class="card-image" src="${item.img}" alt="${title}"/>`
+      ? html`<img class="card-image" src="${item.img}" alt="${title}" loading="lazy"/>`
       : ''; 
     const video = item && item.video
-      ? html`<iframe class="card-video" width="100%" height="315" src="${item.video}" frameBorder="0" allowFullScreen/>`
+      ? html`<iframe class="card-video" width="100%" height="315" src="${item.video}" frameBorder="0" allowFullScreen loading="lazy"></iframe>`
       : '';
 
     return html`


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #205 

## Summary of Changes
1. Add `loading=lazy` attribute to all `<iframe>` and `<img>` in Cards