### PR TITLE
point to personal github profile for social github link

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -2,9 +2,10 @@
 
 I find myself most passionate about helping people learn more about technology and how to improve their process and workflows.  I like to do so through software projects that are well designed, tested, performant, and maintained in a way that advocates for both user _and_ developer experiences.  My broad range of technical knowledge and capabilities, creativity, interpersonal skills, and a good splash of entrepreneurial spirit make me a valuable contributor to any project.
 
-**The Greenhouse** is my platform for growing and building ideas, projects, and businesses with pragmatic technology solutions leveraging some of the best tools available today. Projects are designed and developed to be performant and maintainable, automated in their delivery (CI / CD) and most importantly, enable great user experiences (UX).  To see what we're up to, you can see some of our open source projects in our [GitHub](https://github.com/thegreenhouseio)
+**The Greenhouse** is my space for growing and building ideas, projects, and businesses with pragmatic technology solutions leveraging some of the best tools available today. Projects are designed and developed to be performant and maintainable, automated in their delivery (CI / CD) and most importantly, enable great user experiences (UX).
 
 I'm always up to something online be it on [twitter](https://twitter.com/thegreenhouseio) [Medium](https://medium.com/@thegreenhouseio), or around the local [Rhode Island Tech Meetup Community](https://www.pvdgeeks.org), so I hope to hear from you!
 
 <p class="cta"><i>Let's build something great!</i></p>
+
 <hr/>

--- a/src/services/social-links/social-links-service.js
+++ b/src/services/social-links/social-links-service.js
@@ -11,7 +11,7 @@ class SocialLinksService {
       url: 'https://medium.com/@thegreenhouseio'
     }, {
       name: 'github',
-      url: 'https://github.com/thegreenhouseio'
+      url: 'https://github.com/thescientist13'
     }];
   }
 

--- a/src/services/social-links/social-links-service.spec.js
+++ b/src/services/social-links/social-links-service.spec.js
@@ -33,7 +33,7 @@ describe('SocialLinksService', () => {
       expect(links[2].url).toBe('https://medium.com/@thegreenhouseio');
   
       expect(links[3].name).toBe('github');
-      expect(links[3].url).toBe('https://github.com/thegreenhouseio');
+      expect(links[3].url).toBe('https://github.com/thescientist13');
     });
 
   });
@@ -54,7 +54,7 @@ describe('SocialLinksService', () => {
       expect(links.get('linkedin')).toBe('https://www.linkedin.com/in/owen-buckley-91393447/');
       expect(links.get('twitter')).toBe('https://twitter.com/thegreenhouseio');
       expect(links.get('medium')).toBe('https://medium.com/@thegreenhouseio');
-      expect(links.get('github')).toBe('https://github.com/thegreenhouseio');
+      expect(links.get('github')).toBe('https://github.com/thescientist13');
     });
 
   });
@@ -74,7 +74,7 @@ describe('SocialLinksService', () => {
       expect(links[0]).toBe('https://www.linkedin.com/in/owen-buckley-91393447/');
       expect(links[1]).toBe('https://twitter.com/thegreenhouseio');
       expect(links[2]).toBe('https://medium.com/@thegreenhouseio');
-      expect(links[3]).toBe('https://github.com/thegreenhouseio');
+      expect(links[3]).toBe('https://github.com/thescientist13');
     });
 
   });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
Now that GitHub supports customizing of [GitHub profiles](https://github.com/thescientist13/thescientist13), the best representation of my activity stream would come from there instead.
https://github.com/thescientist13

![Screen Shot 2021-06-19 at 2 16 26 PM](https://user-images.githubusercontent.com/895923/122651755-fd077500-d108-11eb-9c82-47040180d2a3.png)
ch