### PR TITLE
explicit `0` padding on header component `<h2>` tag

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -3,6 +3,10 @@
     width: 100%;
   }
 
+  & h2 {
+    padding: 0;
+  }
+
   & .header a {
     text-decoration: none;
   }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #232 

## Summary of Changes
So yes as part of #230 , because the header was designed with Shadow DOM in mind, when the CSS is rendered in the HTML, the [page level `h2` styling](https://github.com/thegreenhouseio/www.thegreenhouse.io/blob/3.1.0/src/templates/page.html#L6) will now apply a margin globally, which is what throws of the alignment just on the home page
<img width="1662" alt="Screen Shot 2021-07-28 at 12 20 10 PM" src="https://user-images.githubusercontent.com/895923/127359864-fb08a1f6-e3d3-454b-8d98-13b83c8eb10b.png">

So, easiest is to just explicitly set the value.