### PR TITLE
improve nav breakdown and responsiveness of items

### DIFF
--- a/src/components/navigation/navigation.css
+++ b/src/components/navigation/navigation.css
@@ -1,7 +1,6 @@
 :host {
   & .navigation {
     display: block;
-    width: 40%;
     margin: 25px auto;
     text-align: center;
   }
@@ -21,5 +20,11 @@
   & .navigation a {
     color: #020202;
     font-size: 1.5em;
+  }
+}
+
+@media (max-width: 780px) {
+  .navigation ul {
+    column-count: 2
   }
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Just noticed the nav breaks funny at lower break points
<img width="1133" alt="Screen Shot 2022-02-28 at 20 45 36" src="https://user-images.githubusercontent.com/895923/156089209-3591fa91-3833-4445-abaa-4b86812315e8.png">


## Summary of Changes
1. Now at lower break points it will just got to two columns
<img width="580" alt="Screen Shot 2022-02-28 at 20 47 31" src="https://user-images.githubusercontent.com/895923/156089302-de1d4483-e39e-4489-aabc-d6ed0e06f06d.png">